### PR TITLE
Uncapitalize in and ut

### DIFF
--- a/web/src/components/LoginToolbar.tsx
+++ b/web/src/components/LoginToolbar.tsx
@@ -11,7 +11,7 @@ function LoginToolbar(): ReactElement {
     return (
       <Link to="/auth/signout">
         <Button outlined color="white" className="ring-offset-primary-300">
-          Logga Ut
+          Logga ut
         </Button>
       </Link>
     );
@@ -19,7 +19,7 @@ function LoginToolbar(): ReactElement {
     return (
       <Link to="/auth/signin">
         <Button outlined color="white" className="ring-offset-primary-300">
-          Logga In
+          Logga in
         </Button>
       </Link>
     );


### PR DESCRIPTION
It seems like many platforms, like GitHub, have a convention of only capitalizing the first word of text on buttons (see "Close pull request" button at the bottom of this page).

Maybe it should look the same in this application?